### PR TITLE
Fix README.md so that Step 1 opens after generated

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -37,8 +37,7 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
-    # 2. The STEP is currently '0' (see update-step.sh)
-    # 3. This is the first workflow run on the repository
+    # 2. The STEP is currently '0'
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
     if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 0 }}

--- a/.github/workflows/1-create-beta-release.yml
+++ b/.github/workflows/1-create-beta-release.yml
@@ -35,6 +35,7 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 1. The STEP is currently '1'
     # 1. The tag for the published release is v0.9
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions

--- a/.github/workflows/3-release-pr-opened.yml
+++ b/.github/workflows/3-release-pr-opened.yml
@@ -35,7 +35,8 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
-    # 2. The pull request head branch is 'release-v1.0' 
+    # 1. The STEP is currently '3'
+    # 1. The pull request head branch is 'release-v1.0'
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
     if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 3 && github.head_ref == 'release-v1.0' }}

--- a/.github/workflows/4-release-notes-and-merge.yml
+++ b/.github/workflows/4-release-notes-and-merge.yml
@@ -39,11 +39,12 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
-    # 2. The pull request was closed through a merge
-    # 3. The pull request head branch is release-v1.0
+    # 1. The STEP is currently '4'
+    # 1. The pull request was closed through a merge
+    # 1. The pull request head branch is release-v1.0
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 4 && github.event.pull_request.merged == true && github.head_ref == 'release-v1.0'}}
+    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 4 && github.event.pull_request.merged == true && github.head_ref == 'release-v1.0' }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest

--- a/.github/workflows/5-finalize-release.yml
+++ b/.github/workflows/5-finalize-release.yml
@@ -36,6 +36,7 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 1. The STEP is currently '5'
     # 1. The tag for the published release is v1.0.0
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions

--- a/.github/workflows/6-commit-hotifx.yml
+++ b/.github/workflows/6-commit-hotifx.yml
@@ -38,8 +38,9 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
-    # 2. The pull request was closed through a merge
-    # 3. The pull request head branch is hotfix-v1.0.1
+    # 1. The STEP is currently '6'
+    # 1. The pull request was closed through a merge
+    # 1. The pull request head branch is hotfix-v1.0.1
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
     if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 6 && github.event.pull_request.merged == true && github.head_ref == 'hotfix-v1.0.1' }}

--- a/.github/workflows/7-create-hotfix-release.yml
+++ b/.github/workflows/7-create-hotfix-release.yml
@@ -35,6 +35,7 @@ jobs:
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 1. The STEP is currently '7'
     # 1. The tag for the published release is v1.0.1
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GitHub releases allow your team to package and provide software to your users ba
 <!--endstep0-->
 
 <!--Step 1-->
-<details id=1 >
+<details id=1>
 <summary><h2>Step 1: Create a beta release</h2></summary>
 
 ### The GitHub flow


### PR DESCRIPTION
* README.md -- `<details id=1>`

* workflows -- Add some comments to clarify when each action runs

### Why:

Closes #2

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
In README.md
`<details id=1 >` &rarr; `<details id=1>`
Add some minor comments to workflows (complement of #6)

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
