### PR TITLE
Fix the tip on going to the Releases page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Before using a release based workflow for a larger release, let's create a tag a
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab.
 1. Go to the **Releases** page for this repository.
-    - You can click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click **0 releases**.
+    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link_
 1. Click **Create a new release**
 1. In the field for _Tag version_, specify a number. In this case, use **v0.9**. Keep the _Target_ as **main**
 1. Give the release a title, like "First beta release". If you'd like, you could also give the release a short description

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Releases are usually made of many smaller changes. Since we don't know of any bu
 
 ### :keyboard: Activity: Update `base.css`
 
-1. Create a new branch and change the `body` CSS declaration in `base.css` to match what is below. This will set the page background to black
+1. Create a new branch from the `main` branch and change the `body` CSS declaration in `base.css` to match what is below. This will set the page background to black
 ```
 body {
     background-color: black;

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Now let's change our recently automated release from _draft_ to _latest release_
     - To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link
 1. Click the **Edit** button next to your draft release
 1. Ensure the _Target_ branch is set to `main`
-1. Click **Update release**
+1. Click **Publish release**
 1. Wait about 20 seconds then refresh this page for the next step
 
 </details>

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Before using a release based workflow for a larger release, let's create a tag a
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab.
 1. Go to the **Releases** page for this repository.
-    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link_
+    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link._
 1. Click **Create a new release**
 1. In the field for _Tag version_, specify a number. In this case, use **v0.9**. Keep the _Target_ as **main**
 1. Give the release a title, like "First beta release". If you'd like, you could also give the release a short description


### PR DESCRIPTION
### Why:

I found three confusing instructions in README.md.
Closes #11

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
#### Step 1
The tip on going to the **Releases** page
#### Step 2
Clarify the branch from which you should create a new branch (#38)
#### Step 5
**Update release** &rarr; **Publish release** (#35)

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
