### PR TITLE
Need to create PRs manually

### DIFF
--- a/.github/script/create-hotfix-pr.sh
+++ b/.github/script/create-hotfix-pr.sh
@@ -31,12 +31,5 @@ git commit -m "Set game background back to black"
 echo "Push feature branch"
 git push --set-upstream origin $FEATURE_BRANCH
 
-echo "Create PR to hotfix release branch and merge"
-gh pr create --base $RELEASE_BRANCH --head $FEATURE_BRANCH --title "Hotfix for broken game style" --body "Fixed bug, set game background back to black"
-gh pr merge --squash $FEATURE_BRANCH
-
-echo "Create PR for hotfix to main"
-gh pr create --base main --head $RELEASE_BRANCH --title "Hotfix v1.0.1" --body "Fixed bug introduced in last production release - set game background back to black."
-
 echo "Restore main"
 git checkout main

--- a/.github/script/initialize-repository.sh
+++ b/.github/script/initialize-repository.sh
@@ -31,9 +31,5 @@ git commit -m "Changed game text colors to green"
 echo "Push feature branch"
 git push --set-upstream origin $FEATURE_BRANCH
 
-echo "Create PR to release branch and merge"
-gh pr create --base $RELEASE_BRANCH --head $FEATURE_BRANCH --title "Updated game text style" --body "Updated game text color to green"
-gh pr merge --squash update-text-colors
-
 echo "Restore main"
 git checkout main

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ We'll submit a hotfix by creating and merging the pull request.
 ### :keyboard: Activity: Create and merge the hotfix pull request
 
 1. Open a pull request with `hotfix-v1.0.1` as the `base` branch, and `fix-game-background` as the `compare` branch
-1. Fill in the pull request template to describe your changes, you can set the pull request title to `Hotfix for broken game style` and you can include a detailed pull request body, an example is below
+1. Fill in the pull request template to describe your changes. You can set the pull request title to `Hotfix for broken game style`. You can include a detailed pull request body, an example is below:
     ```
     ## Description:
     - Fixed bug, set game background back to black

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Before using a release based workflow for a larger release, let's create a tag a
 To set the stage for later, let's also add a bug that we'll fix as part of the release workflow in later steps.  We've already created a `update-text-colors` branch for you so let's create and merge a pull request with this branch.
 
 1. Open a **new pull request** with `base: release-v1.0` and `compare: update-text-colors`
-1. Set the pull request title to `Updated game text style` and you can include a detailed pull request body, an example is below
+1. Set the pull request title to `Updated game text style`. You can include a detailed pull request body, an example is below:
     ```
     ## Description:
     - Updated game text color to green

--- a/README.md
+++ b/README.md
@@ -235,14 +235,23 @@ _Tip: Sometimes GitHub Pages takes a few minutes to update. Your page might not 
 
 "Hotfixes", or a quick fix to address a bug in software, are a normal part of development. Oftentimes you'll see application updates whose only description is "bug fixes".
 
-When bugs come up after you release a version, you'll need to address them.
+When bugs come up after you release a version, you'll need to address them.  We've already created a `hotfix-v1.0.1` and `fix-game-background` branches for you to start.
 
-We've already created this branch and pull request. The suggested change will be merged into the main branch. Later we will `cherry-pick` the hotfix commits into the release branch.
+We'll submit a hotfix by approving and merging the pull request.
 
-Submit a hotfix by approving and merging the pull request.
+### :keyboard: Activity: Create and merge the hotfix pull request
 
-### :keyboard: Activity: Merge the hotfix
-1. In a separate tab, go to the **Pull requests** page and view the open pull request
+1. Open a pull request with `hotfix-v1.0.1` as the `base` branch, and `fix-game-background` as the `compare` branch
+1. Fill in the pull request template to describe your changes (e.g. `Hotfix for broken game style` as the title and `Fixed bug, set game background back to black` as the body content)
+1. Review the changes and approve the pull request
+1. Click **Merge pull request**
+1. Wait about 20 seconds then refresh this page for the next step
+
+Now we want these changes merged into `main` as well so let's create and merge a pull request with our hotfix to `main`.
+### :keyboard: Activity: Create the release pull request
+
+1. Open a pull request with `main` as the `base` branch, and `hotfix-v1.0.1` as the `compare` branch
+1. Fill in the pull request template to describe your changes (e.g. `Hotfix v1.0.1` as the title and `Fixed bug introduced in last production release - set game background back to black` as the body content)
 1. Review the changes and approve the pull request
 1. Click **Merge pull request**
 1. Wait about 20 seconds then refresh this page for the next step

--- a/README.md
+++ b/README.md
@@ -65,9 +65,24 @@ Before using a release based workflow for a larger release, let's create a tag a
 1. Click **Create a new release**
 1. In the field for _Tag version_, specify a number. In this case, use **v0.9**. Keep the _Target_ as **main**
 1. Give the release a title, like "First beta release". If you'd like, you could also give the release a short description
-1. Select the checkbox next to **This is a pre-release**, since it is representing a beta version
+1. Select the checkbox next to **Set as a pre-release**, since it is representing a beta version
 1. Click **Publish release**
 1. Wait about 20 seconds then refresh this page for the next step
+
+### :keyboard: Activity: Introduce a bug to be fixed later
+
+To set the stage for later, let's also add a bug that we'll fix as part of the release workflow in later steps.  We've already created a `update-text-colors` branch for you so let's create and merge a pull request with this branch.
+
+1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab
+1. Open a **new pull request** with `base: release` and `compare: update-text-colors`
+1. Set the pull request title to `Updated game text style` and you can include a detailed pull request body, an example is below
+    ```
+    ## Description:
+    - Updated game text color to green
+    ```
+1. Click `Create pull request`
+1. We'll also merge this pull request now so click `Merge pull request` and delete your branch.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 
@@ -146,6 +161,7 @@ Let's make a new pull request comparing the `release-v1.0` branch to the `main` 
     - Changed page background color to black.
     - Changed game text color to green.
     ```
+1. Click `Create pull request`
 1. Wait about 20 seconds then refresh this page for the next step
 
 </details>
@@ -214,7 +230,7 @@ Now let's change our recently automated release from _draft_ to _latest release_
     - To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link
 1. Click the **Edit** button next to your draft release
 1. Ensure the _Target_ branch is set to `main`
-1. Click **Update release**
+1. Click **Publish release**
 1. Wait about 20 seconds then refresh this page for the next step
 
 </details>
@@ -237,7 +253,7 @@ _Tip: Sometimes GitHub Pages takes a few minutes to update. Your page might not 
 
 When bugs come up after you release a version, you'll need to address them.  We've already created a `hotfix-v1.0.1` and `fix-game-background` branches for you to start.
 
-We'll submit a hotfix by approving and merging the pull request.
+We'll submit a hotfix by creating and merging the pull request.
 
 ### :keyboard: Activity: Create and merge the hotfix pull request
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Before using a release based workflow for a larger release, let's create a tag a
 To set the stage for later, let's also add a bug that we'll fix as part of the release workflow in later steps.  We've already created a `update-text-colors` branch for you so let's create and merge a pull request with this branch.
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab
-1. Open a **new pull request** with `base: release` and `compare: update-text-colors`
+1. Open a **new pull request** with `base: release-v1.0` and `compare: update-text-colors`
 1. Set the pull request title to `Updated game text style` and you can include a detailed pull request body, an example is below
     ```
     ## Description:
@@ -119,8 +119,9 @@ body {
     background-color: black;
 }
 ```
-2. Open a pull request with `release-v1.0` as the `base` branch, and your new branch as `compare`
-3. Fill in the pull request template to describe your changes
+1. Open a pull request with `release-v1.0` as the `base` branch, and your new branch as `compare`
+1. Fill in the pull request template to describe your changes
+1. Click `Create pull request`
 
 ### Merge the new feature to the release branch
 Even with releases, the GitHub flow is still an important strategy for working with your team. It's a good idea to use short-lived branches for quick feature additions and bug fixes.
@@ -259,16 +260,15 @@ We'll submit a hotfix by creating and merging the pull request.
 
 1. Open a pull request with `hotfix-v1.0.1` as the `base` branch, and `fix-game-background` as the `compare` branch
 1. Fill in the pull request template to describe your changes (e.g. `Hotfix for broken game style` as the title and `Fixed bug, set game background back to black` as the body content)
-1. Review the changes and approve the pull request
-1. Click **Merge pull request**
-1. Wait about 20 seconds then refresh this page for the next step
+1. Review the changes and click `Create pull request`
+1. We want to merge this into our hotfix branch now so click **Merge pull request**
 
 Now we want these changes merged into `main` as well so let's create and merge a pull request with our hotfix to `main`.
 ### :keyboard: Activity: Create the release pull request
 
 1. Open a pull request with `main` as the `base` branch, and `hotfix-v1.0.1` as the `compare` branch
 1. Fill in the pull request template to describe your changes (e.g. `Hotfix v1.0.1` as the title and `Fixed bug introduced in last production release - set game background back to black` as the body content)
-1. Review the changes and approve the pull request
+1. Review the changes and click `Create pull request`
 1. Click **Merge pull request**
 1. Wait about 20 seconds then refresh this page for the next step
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,11 @@ Before using a release based workflow for a larger release, let's create a tag a
 1. Give the release a title, like "First beta release". If you'd like, you could also give the release a short description
 1. Select the checkbox next to **Set as a pre-release**, since it is representing a beta version
 1. Click **Publish release**
-1. Wait about 20 seconds then refresh this page for the next step
 
 ### :keyboard: Activity: Introduce a bug to be fixed later
 
 To set the stage for later, let's also add a bug that we'll fix as part of the release workflow in later steps.  We've already created a `update-text-colors` branch for you so let's create and merge a pull request with this branch.
 
-1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab
 1. Open a **new pull request** with `base: release-v1.0` and `compare: update-text-colors`
 1. Set the pull request title to `Updated game text style` and you can include a detailed pull request body, an example is below
     ```
@@ -81,7 +79,7 @@ To set the stage for later, let's also add a bug that we'll fix as part of the r
     - Updated game text color to green
     ```
 1. Click `Create pull request`
-1. We'll also merge this pull request now so click `Merge pull request` and delete your branch.
+1. We'll  merge this pull request now so click `Merge pull request` and delete your branch.
 1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
@@ -106,7 +104,7 @@ Like the `main` branch, you can protect release branches. This means you can pro
 
 ### Add a feature
 
-Releases are usually made of many smaller changes. Since we don't know of any bugs, we'll focus on a few features to update on our game before the version update.
+Releases are usually made of many smaller changes. Let's pretend we don't know about the bug we added earlier and we'll focus on a few features to update our game before the version update.
 
 - You should update the page background color to black.
 - I'll help you change the text colors to green.
@@ -119,7 +117,7 @@ body {
     background-color: black;
 }
 ```
-1. Open a pull request with `release-v1.0` as the `base` branch, and your new branch as `compare`
+1. Open a pull request with `release-v1.0` as the `base` branch, and your new branch as the `compare` branch
 1. Fill in the pull request template to describe your changes
 1. Click `Create pull request`
 
@@ -153,7 +151,6 @@ To expedite the creation of this pull request, I've added a pull request templat
 ### :keyboard: Activity: Open a release pull request
 Let's make a new pull request comparing the `release-v1.0` branch to the `main` branch.
 
-1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab
 1. Open a **new pull request** with `base: main` and `compare: release-v1.0`
 1. Ensure the title of your pull request is **Release v1.0**
 1. Include a detailed pull request body, an example is below
@@ -259,7 +256,11 @@ We'll submit a hotfix by creating and merging the pull request.
 ### :keyboard: Activity: Create and merge the hotfix pull request
 
 1. Open a pull request with `hotfix-v1.0.1` as the `base` branch, and `fix-game-background` as the `compare` branch
-1. Fill in the pull request template to describe your changes (e.g. `Hotfix for broken game style` as the title and `Fixed bug, set game background back to black` as the body content)
+1. Fill in the pull request template to describe your changes, you can set the pull request title to `Hotfix for broken game style` and you can include a detailed pull request body, an example is below
+    ```
+    ## Description:
+    - Fixed bug, set game background back to black
+    ```
 1. Review the changes and click `Create pull request`
 1. We want to merge this into our hotfix branch now so click **Merge pull request**
 
@@ -267,7 +268,11 @@ Now we want these changes merged into `main` as well so let's create and merge a
 ### :keyboard: Activity: Create the release pull request
 
 1. Open a pull request with `main` as the `base` branch, and `hotfix-v1.0.1` as the `compare` branch
-1. Fill in the pull request template to describe your changes (e.g. `Hotfix v1.0.1` as the title and `Fixed bug introduced in last production release - set game background back to black` as the body content)
+1. Fill in the pull request template to describe your changes, you can set the pull request title to `Hotfix v1.0.1` and you can include a detailed pull request body, an example is below
+    ```
+    ## Description:
+    - Fixed bug introduced in last production release - set game background back to black
+    ```
 1. Review the changes and click `Create pull request`
 1. Click **Merge pull request**
 1. Wait about 20 seconds then refresh this page for the next step

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To set the stage for later, let's also add a bug that we'll fix as part of the r
     - Updated game text color to green
     ```
 1. Click `Create pull request`
-1. We'll  merge this pull request now so click `Merge pull request` and delete your branch.
+1. We'll merge this pull request now. Click `Merge pull request` and delete your branch.
 1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>


### PR DESCRIPTION
### Why:

towards https://github.com/github/skills/issues/96

because of default Actions settings we need to adjust the course so the learner manually creates PRs

### What's being changed:

* remove use of `gh pr` and ask user to create PRs manually

Did involve some small-ish course content updates and also updated small bits here and there just so the instructions match the UI, but I did run through the course a few times and completed successfully with no problems.

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
