### PR TITLE
Make the tips consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,23 @@ Before using a release based workflow for a larger release, let's create a tag a
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab.
 1. Go to the **Releases** page for this repository.
     - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link._
-1. Click **Create a new release**
-1. In the field for _Tag version_, specify a number. In this case, use **v0.9**. Keep the _Target_ as **main**
-1. Give the release a title, like "First beta release". If you'd like, you could also give the release a short description
-1. Select the checkbox next to **Set as a pre-release**, since it is representing a beta version
-1. Click **Publish release**
+1. Click **Create a new release**.
+1. In the field for _Tag version_, specify a number. In this case, use **v0.9**. Keep the _Target_ as **main**.
+1. Give the release a title, like "First beta release". If you'd like, you could also give the release a short description.
+1. Select the checkbox next to **Set as a pre-release**, since it is representing a beta version.
+1. Click **Publish release**.
 
 ### :keyboard: Activity: Introduce a bug to be fixed later
 
 To set the stage for later, let's also add a bug that we'll fix as part of the release workflow in later steps.  We've already created a `update-text-colors` branch for you so let's create and merge a pull request with this branch.
 
-1. Open a **new pull request** with `base: release-v1.0` and `compare: update-text-colors`
+1. Open a **new pull request** with `base: release-v1.0` and `compare: update-text-colors`.
 1. Set the pull request title to `Updated game text style`. You can include a detailed pull request body, an example is below:
     ```
     ## Description:
     - Updated game text color to green
     ```
-1. Click `Create pull request`
+1. Click `Create pull request`.
 1. We'll merge this pull request now. Click `Merge pull request` and delete your branch.
 1. Wait about 20 seconds then refresh this page for the next step.
 
@@ -115,15 +115,15 @@ Releases are usually made of many smaller changes. Let's pretend we don't know a
 
 ### :keyboard: Activity: Update `base.css`
 
-1. Create a new branch off of the `main` branch and change the `body` CSS declaration in `base.css` to match what is below. This will set the page background to black
+1. Create a new branch off of the `main` branch and change the `body` CSS declaration in `base.css` to match what is below. This will set the page background to black.
 ```
 body {
     background-color: black;
 }
 ```
-1. Open a pull request with `release-v1.0` as the `base` branch, and your new branch as the `compare` branch
-1. Fill in the pull request template to describe your changes
-1. Click `Create pull request`
+1. Open a pull request with `release-v1.0` as the `base` branch, and your new branch as the `compare` branch.
+1. Fill in the pull request template to describe your changes.
+1. Click `Create pull request`.
 
 ### Merge the new feature to the release branch
 Even with releases, the GitHub flow is still an important strategy for working with your team. It's a good idea to use short-lived branches for quick feature additions and bug fixes.
@@ -157,16 +157,16 @@ To expedite the creation of this pull request, I've added a pull request templat
 ### :keyboard: Activity: Open a release pull request
 Let's make a new pull request comparing the `release-v1.0` branch to the `main` branch.
 
-1. Open a **new pull request** with `base: main` and `compare: release-v1.0`
-1. Ensure the title of your pull request is **Release v1.0**
-1. Include a detailed pull request body, an example is below
+1. Open a **new pull request** with `base: main` and `compare: release-v1.0`.
+1. Ensure the title of your pull request is **Release v1.0**.
+1. Include a detailed pull request body, an example is below:
     ```
     ## Description: 
     - Changed page background color to black.
     - Changed game text color to green.
     ```
-1. Click `Create pull request`
-1. Wait about 20 seconds then refresh this page for the next step
+1. Click `Create pull request`.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 
@@ -182,22 +182,22 @@ _Thanks for opening that pull request :dancer:_
 ### :keyboard: Activity: Generate release notes
 
 1. In a separate tab, go to the **Releases** page for this repository.
-    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link_
-1. Click the **Draft a new release** button
-1. In the field for _Tag version_, specify `v1.0.0`
-1. To the right of the tag dropdown, click the _Target_ dropddown and select the `release-v1.0` branch
-    - _Tip: This is temporary in order to generate release notes based on the changes in this branch_
-1. To the top right of the description text box, click **Generate release notes**
-1. Review the release notes in the text box and customize the content if desired
-1. Set the _Target_ branch back to the `main`, as this is the branch you want to create your tag on once the release branch is merged
-1. Click **Save draft**, as you will publish this release in the next step
+    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link._
+1. Click the **Draft a new release** button.
+1. In the field for _Tag version_, specify `v1.0.0`.
+1. To the right of the tag dropdown, click the _Target_ dropddown and select the `release-v1.0` branch.
+    - _Tip: This is temporary in order to generate release notes based on the changes in this branch._
+1. To the top right of the description text box, click **Generate release notes**.
+1. Review the release notes in the text box and customize the content if desired.
+1. Set the _Target_ branch back to the `main`, as this is the branch you want to create your tag on once the release branch is merged.
+1. Click **Save draft**, as you will publish this release in the next step.
 
 You can now [merge](https://docs.github.com/en/get-started/quickstart/github-glossary#merge) your pull request!
 
 ### :keyboard: Activity: Merge into main
 
 1. In a separate tab, go to the **Pull requests** page for this repository.
-1. Open your **Release v1.0** pull request
+1. Open your **Release v1.0** pull request.
 1. Click **Merge pull request**.
 1. Wait about 20 seconds then refresh this page for the next step.
 
@@ -234,12 +234,12 @@ Now let's change our recently automated release from _draft_ to _latest release_
 
 ### :keyboard: Activity: Finalize release
 
-1. In a separate tab, go to the **Releases** page for this repository
-    - To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link
-1. Click the **Edit** button next to your draft release
-1. Ensure the _Target_ branch is set to `main`
-1. Click **Publish release**
-1. Wait about 20 seconds then refresh this page for the next step
+1. In a separate tab, go to the **Releases** page for this repository.
+    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link._
+1. Click the **Edit** button next to your draft release.
+1. Ensure the _Target_ branch is set to `main`.
+1. Click **Publish release**.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 
@@ -267,27 +267,27 @@ We'll submit a hotfix by creating and merging the pull request.
 
 ### :keyboard: Activity: Create and merge the hotfix pull request
 
-1. Open a pull request with `hotfix-v1.0.1` as the `base` branch, and `fix-game-background` as the `compare` branch
+1. Open a pull request with `hotfix-v1.0.1` as the `base` branch, and `fix-game-background` as the `compare` branch.
 1. Fill in the pull request template to describe your changes. You can set the pull request title to `Hotfix for broken game style`. You can include a detailed pull request body, an example is below:
     ```
     ## Description:
     - Fixed bug, set game background back to black
     ```
-1. Review the changes and click `Create pull request`
-1. We want to merge this into our hotfix branch now so click **Merge pull request**
+1. Review the changes and click `Create pull request`.
+1. We want to merge this into our hotfix branch now so click **Merge pull request**.
 
 Now we want these changes merged into `main` as well so let's create and merge a pull request with our hotfix to `main`.
 ### :keyboard: Activity: Create the release pull request
 
-1. Open a pull request with `main` as the `base` branch, and `hotfix-v1.0.1` as the `compare` branch
-1. Fill in the pull request template to describe your changes, you can set the pull request title to `Hotfix v1.0.1` and you can include a detailed pull request body, an example is below
+1. Open a pull request with `main` as the `base` branch, and `hotfix-v1.0.1` as the `compare` branch.
+1. Fill in the pull request template to describe your changes, you can set the pull request title to `Hotfix v1.0.1` and you can include a detailed pull request body, an example is below:
     ```
     ## Description:
     - Fixed bug introduced in last production release - set game background back to black
     ```
-1. Review the changes and click `Create pull request`
-1. Click **Merge pull request**
-1. Wait about 20 seconds then refresh this page for the next step
+1. Review the changes and click `Create pull request`.
+1. Click **Merge pull request**.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 
@@ -307,15 +307,15 @@ With descriptive pull requests and auto generated release notes, you don't have 
 
 ### :keyboard: Activity: Complete release
 
-1. In a separate tab, go to to the **Releases** page for this repository
-    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link_
-1. Click the **Draft a new release** button
-1. Set the _Target_ branch to `main`
+1. In a separate tab, go to to the **Releases** page for this repository.
+    - _Tip: To reach this page, click the **Code** tab at the top of your repository. Then, find the navigation bar below the repository description, and click the **Releases** heading link._
+1. Click the **Draft a new release** button.
+1. Set the _Target_ branch to `main`.
     - _Tip: Practice your semantic version syntax. What should the tag and title for this release be?_
-1. To the top right of the description text box, click **Generate release notes**
-1. Review the release notes in the text box and customize the content if desired
-1. Click **Publish release**
-1. Wait about 20 seconds then refresh this page for the next step
+1. To the top right of the description text box, click **Generate release notes**.
+1. Review the release notes in the text box and customize the content if desired.
+1. Click **Publish release**.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 


### PR DESCRIPTION
### Why:

The tip to reach the **Releases** page should be italicized.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
- Add "Tips:" and italicize l. 238 of README.md.
- Correct the punctuation

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
